### PR TITLE
Change Saml wrapper methods to return promises

### DIFF
--- a/wrappers/saml/saml.js
+++ b/wrappers/saml/saml.js
@@ -16,50 +16,39 @@ extends Wrapper {
 
 	_connect(callback) {
 		const saml2 = require('saml2-js');
+		const Promise = require('bluebird');
+
 		// Create identity provider.
 		this.idp = new saml2.IdentityProvider(this.config.idp_options);
+		Promise.promisifyAll(this.idp);
 
 		// Create service provider.
 		this.sp = new saml2.ServiceProvider(this.config.sp_options);
+		Promise.promisifyAll(this.sp);
 
 		callback();
 	}
 
-	loginRequest(callback) {
-		this.sp.create_login_request_url(this.idp, {}, function(err, login_url, request_id) {
-			if (err != null) {
-				callback(err);
-			} else {
-				callback(null, login_url);
-			}
-		});
+	loginRequest() {
+		return this.sp.create_login_request_urlAsync(this.idp, {});
 	}
 
 	getMetadata() {
 		return this.sp.create_metadata();
 	}
 
-	assert(options, callback) {
-		this.sp.post_assert(this.idp, options, function(err, saml_response) {
-			if (err != null) {
-				callback(err);
-			} else {
-				callback(null, {
+	assert(options) {
+		return this.sp.post_assertAsync(this.idp, options)
+			.then((saml_response) => {
+				return {
 					name_id: saml_response.user.name_id,
 					session_index: saml_response.user.session_index
-				});
-			}
-		});
+				};
+			});
 	}
 
-	logoutRequest(options, callback) {
-		this.sp.create_logout_request_url(this.idp, options, function(err, logout_url) {
-			if (err != null) {
-				callback(err);
-			} else {
-				callback(null, logout_url);
-			}
-		});
+	logoutRequest(options) {
+		return this.sp.create_logout_request_urlAsync(this.idp, options);
 	}
 
 }


### PR DESCRIPTION
The Saml wrapper has been adapted so that its methods return promises, instead of accepting error-first callbacks.

The "saml2-js" library did not provide a Promise-based API, so a "promisify" utility was used to adapt the "saml2-js" methods to ones that work with promises. Specifically, the [Promise.promisifyAll](http://bluebirdjs.com/docs/api/promise.promisifyall.html) function from the bluebird Promise library was used.

Note that in addition to the "saml2-js" package, "bluebird" needs to
also be installed for this wrapper to be used.